### PR TITLE
Fix page break not working on some browsers

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -67,7 +67,7 @@ class syntax_plugin_pagebreak extends DokuWiki_Syntax_Plugin {
             if(is_a($renderer,'renderer_plugin_dw2pdf')){
                 $renderer->doc .= "<pagebreak />";
             } else {
-                $renderer->doc .= "<div style=\"page-break-after:always\"></DIV>";
+                $renderer->doc .= "<div style=\"page-break-after:always\";></div>";
             }
             return true;
         } else if ($mode == 'odt') {

--- a/syntax.php
+++ b/syntax.php
@@ -67,7 +67,7 @@ class syntax_plugin_pagebreak extends DokuWiki_Syntax_Plugin {
             if(is_a($renderer,'renderer_plugin_dw2pdf')){
                 $renderer->doc .= "<pagebreak />";
             } else {
-                $renderer->doc .= "<div style=\"page-break-after:always\";></div>";
+                $renderer->doc .= "<div style=\"page-break-after:always;\"></div>";
             }
             return true;
         } else if ($mode == 'odt') {

--- a/syntax.php
+++ b/syntax.php
@@ -67,7 +67,7 @@ class syntax_plugin_pagebreak extends DokuWiki_Syntax_Plugin {
             if(is_a($renderer,'renderer_plugin_dw2pdf')){
                 $renderer->doc .= "<pagebreak />";
             } else {
-                $renderer->doc .= "<br style=\"page-break-after:always;\">";
+                $renderer->doc .= "<div style=\"page-break-after:always\"></DIV>";
             }
             return true;
         } else if ($mode == 'odt') {


### PR DESCRIPTION
`<br style="page-break-after:always;">` doesn't work on all browsers. Changed it to `<div style="page-break-after:always;"></div>` which should be more reliable.
More detail about pagebreak compatibility is available at https://stackoverflow.com/a/24808741/2393763 and http://www.javascriptkit.com/dhtmltutors/pagebreak.shtml